### PR TITLE
Preference pane thinks it's installed system wide on 10.9

### DIFF
--- a/EnvPane.xcodeproj/project.pbxproj
+++ b/EnvPane.xcodeproj/project.pbxproj
@@ -359,7 +359,7 @@
 		E2ADE0A208395023000B79B2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0500;
 			};
 			buildConfigurationList = 47BFFDF808902CAE003DA0CC /* Build configuration list for PBXProject "EnvPane" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -500,7 +500,6 @@
 		47BFFDF908902CAE003DA0CC /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -547,7 +546,6 @@
 		47BFFDFA08902CAE003DA0CC /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -591,7 +589,6 @@
 		47BFFDFB08902CAE003DA0CC /* Default */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -637,6 +634,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEPLOYMENT_LOCATION = YES;
 				DSTROOT = /;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -656,6 +654,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "EnvPane/EnvPane-Prefix.pch";
 				INFOPLIST_FILE = "EnvPane/EnvPane-Info.plist";
@@ -674,6 +673,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = NO;
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "EnvPane/EnvPane-Prefix.pch";
 				INFOPLIST_FILE = "EnvPane/EnvPane-Info.plist";

--- a/EnvPane/EnvPane.m
+++ b/EnvPane/EnvPane.m
@@ -196,12 +196,25 @@
         /*
          * ... otherwise start agent.
          */
+      
+        /*
+         * For some reason, subsequent launches of the preference pane are not
+         * finding the agent as loaded. So we load it every time just to
+         * force it to work.
+         */
+        task = [NSTask launchedTaskWithLaunchPath: launchctlPath
+                                        arguments:@[ @"load", [agentConfUrl path]]];
+        [task waitUntilExit];
+        if (task.terminationStatus != 0) {
+          return NO_AssignError(error, NewError(@"Failed to load agent"));
+        }
+      
         task = [NSTask launchedTaskWithLaunchPath: launchctlPath
                                         arguments: @[ @"start", agentLabel ]];
     }
     [task waitUntilExit];
     if( task.terminationStatus != 0 ) {
-        return NO_AssignError( error, NewError( @"Failed to load/start agent" ) );
+        return NO_AssignError( error, NewError( @"Failed to start agent" ) );
     }
 
     return self.agentInstalled = YES;

--- a/EnvPane/EnvPane.m
+++ b/EnvPane/EnvPane.m
@@ -79,8 +79,7 @@
 
 - (BOOL) installAgent: (NSError**) error
 {
-    NSBundle* bundle = self.bundle;
-    NSURL* bundleUrl = bundle.bundleURL;
+    NSString* homeDirectory = NSHomeDirectory();
     NSFileManager* fileManager = NSFileManager.defaultManager;
     NSURL* prefPanesUrl = [fileManager URLForDirectory: NSPreferencePanesDirectory
                                               inDomain: NSUserDomainMask
@@ -89,7 +88,8 @@
                                                  error: error];
     if( !prefPanesUrl ) return NO;
 
-    if( ![bundleUrl.absoluteString hasPrefix: prefPanesUrl.absoluteString] ) {
+    NSRange range = [[prefPanesUrl absoluteString] rangeOfString:homeDirectory];
+    if( range.location == NSNotFound ) {
         return NO_AssignError( error, NewError(
                                    @"This preference pane must be installed for each user individually. "
                                    "Installation for all users is currently not supported. Remove this preference pane "
@@ -102,6 +102,7 @@
      * the preference pane is deleted, enabling the agent to self-destruct
      * itself in that case.
      */
+    NSBundle* bundle = [self bundle];
     NSURL* agentExcutableUrl = [bundle URLForAuxiliaryExecutable: agentExecutableName];
     if( agentExcutableUrl == nil ) {
         return NO_AssignError( error, NewError( @"Can't find agent executable" ) );
@@ -166,7 +167,7 @@
 
     [newAgentConf setValue: @[ agentExecutableLinkUrl.path ]
                     forKey: @"ProgramArguments"];
-    [newAgentConf setValue: @[ bundleUrl.path, [Environment savedEnvironmentPath]]
+    [newAgentConf setValue: @[ [[bundle bundleURL] path], [Environment savedEnvironmentPath]]
                     forKey: @"WatchPaths"];
 
     /*


### PR DESCRIPTION
`[[self bundle] bundleURL]` is returning `nil` on 10.9 for some reason. This is causing EnvPane to think it isn't installed solely for one user. This pull request fixes the problem by altering the detection to use `NSHomeDirectory()`.